### PR TITLE
Fix: add correct label for user namespace

### DIFF
--- a/apps/profiles/upstream/base/namespace-labels.yaml
+++ b/apps/profiles/upstream/base/namespace-labels.yaml
@@ -16,3 +16,4 @@ katib.kubeflow.org/metrics-collector-injection: "enabled"
 serving.kubeflow.org/inferenceservice: "enabled"
 pipelines.kubeflow.org/enabled: "true"
 app.kubernetes.io/part-of: "kubeflow-profile"
+jqdomain.com/ns-type: tenancy


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**


**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
